### PR TITLE
Full edit pass

### DIFF
--- a/draft-porfiri-dhc-dhcpv4-over-dhcpv6-ra.md
+++ b/draft-porfiri-dhc-dhcpv4-over-dhcpv6-ra.md
@@ -107,7 +107,7 @@ The following terms and acronyms are used in this document:
 * Lightweight DHCPv6 Relay Agent (or LDRA):
    This is an extension of the original DHCPv6 Relay Agent mechanism,
    to support also Layer 2 devices performing a Relay Agent function {{RFC6221}}.
-  
+ 
 * DHCPv4 over DHCPv6 Relay Agent (or 4o6RA):
    The 4o6 Relay Agent (as specified in this document)
    is the part of an RA implementing 4o6.

--- a/draft-porfiri-dhc-dhcpv4-over-dhcpv6-ra.md
+++ b/draft-porfiri-dhc-dhcpv4-over-dhcpv6-ra.md
@@ -117,7 +117,7 @@ The following terms and acronyms are used in this document:
 # DHCPv4 over DHCPv6 Relay Agent (4o6RA)
 
 This document assume an network, where IPv4-only clients are connected
-to an uplink network that supports IPv6 only and limited IPv4 services. 
+to an uplink network that supports IPv6 only and limited IPv4 services.
 
 To address such a network setup, this document proposes to extend
 DHCPv6 Relay Agents with  DHCPv4 over DHCPv6, as

--- a/draft-porfiri-dhc-dhcpv4-over-dhcpv6-ra.md
+++ b/draft-porfiri-dhc-dhcpv4-over-dhcpv6-ra.md
@@ -107,7 +107,6 @@ The following terms and acronyms are used in this document:
 * Lightweight DHCPv6 Relay Agent (or LDRA):
    This is an extension of the original DHCPv6 Relay Agent mechanism,
    to support also Layer 2 devices performing a Relay Agent function {{RFC6221}}.
- 
 * DHCPv4 over DHCPv6 Relay Agent (or 4o6RA):
    The 4o6 Relay Agent (as specified in this document)
    is the part of an RA implementing 4o6.


### PR DESCRIPTION
Some editorial changes, nits and clarifications, but I also removed a bit of text that was copied from RFC7341 again (this is just not needed) and re-added some minor parts from the previous draft version. I also re-added a deployment consideration section as the client not being aware is a mayor difference to RFC7341 and needs some care in deployment. This is a bit redundant with some part of the sec considerations now but I think that is fine as this point is important.

In general, I think this proposed change makes the draft shorter and more to the point.